### PR TITLE
Remove image_credentials from pcc-deploy.toml

### DIFF
--- a/pcc-deploy.toml
+++ b/pcc-deploy.toml
@@ -1,7 +1,6 @@
 agent_name = "my-first-agent"
 image = "your-username/my-first-agent:0.1"
 secret_set = "my-first-agent-secrets"
-image_credentials = "${MY_IMAGE_CREDENTIALS}"
 
 [scaling]
 	min_instances = 1


### PR DESCRIPTION
This isn't needed for the quickstart and causes and error. Removing it.