### PR TITLE
bot: remove extra body argument

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -125,7 +125,7 @@ async def bot(args: DailySessionArguments):
     )
 
     try:
-        await main(transport, args.body)
+        await main(transport)
         logger.info("Bot process completed")
     except Exception as e:
         logger.exception(f"Error in bot process: {str(e)}")


### PR DESCRIPTION
This was broken. I'd say let the user handle `arg.body` however they want.